### PR TITLE
Fix long URL rendering in popup results list

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -778,3 +778,27 @@ summary {
   max-width: 100%;
   height: auto;
 }
+
+.result-item {
+  list-style: none;
+  margin: 0.6rem 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.result-item-text {
+  min-width: 0;
+}
+
+.result-item-link {
+  display: block;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.result-item-date {
+  display: block;
+  font-size: 0.8rem;
+}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -125,7 +125,7 @@ function makeList(section, ecoindex) {
 	resultLink.setAttribute("target", "_blank");
 
 	const li = document.createElement("li");
-	li.style.listStyleType = "none";
+	li.classList.add("result-item");
 	li.setAttribute(
 		"title",
 		`(${ecoindex.score} / 100) le ${convertDate(ecoindex.date)}`,
@@ -135,16 +135,18 @@ function makeList(section, ecoindex) {
 	const pageLink = document.createElement("a");
 	pageLink.textContent = ecoindex.url;
 	pageLink.setAttribute("href", ecoindex.url);
-	pageLink.style.paddingLeft = "5px";
-	pageLink.style.textDecoration = "none";
 	pageLink.setAttribute("target", "_blank");
-	li.appendChild(pageLink);
+	pageLink.classList.add("result-item-link");
 
 	const pageLinkDate = document.createElement("span");
-	pageLinkDate.style.fontSize = "0.8rem";
 	pageLinkDate.textContent = `(${convertDate(ecoindex.date)})`;
-	pageLinkDate.style.paddingLeft = "5px";
-	pageLink.appendChild(pageLinkDate);
+	pageLinkDate.classList.add("result-item-date");
+
+	const itemTextWrapper = document.createElement("div");
+	itemTextWrapper.classList.add("result-item-text");
+	itemTextWrapper.appendChild(pageLink);
+	itemTextWrapper.appendChild(pageLinkDate);
+	li.appendChild(itemTextWrapper);
 
 	const ul = section.getElementsByTagName("ul")[0];
 	ul.appendChild(li);


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in the popup results list when URLs are long
- render URL and analysis date on two separate lines in each result list item
- keep grade badge alignment while allowing URL wrapping

## Test plan
- [x] Run `npm run lint`
- [x] Open extension popup with long URLs in "Derniers résultats"
- [x] Confirm there is no horizontal scrollbar and date is on its own line